### PR TITLE
Fix missing return in runBytecode and runBytecodeFile.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ const runBytecode = function (bytecodeBuffer) {
     cachedData: bytecodeBuffer
   });
 
-  script.runInThisContext();
+  return script.runInThisContext();
 };
 
 const compileFile = function (filename, output) {


### PR DESCRIPTION
Rather than open an issue, I figured I'd just submit a pull request.  I noticed this return statement is missing which makes runBytecode and runBytecodeFile a lot less useful.

Thanks for this package, by the way!  It really helped me optimize my node command line tool.