### PR TITLE
Use a Node.js version test instead of a try/catch block

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ const Module = require('module');
 
 v8.setFlagsFromString('--no-lazy');
 
-try {
+if (Number.parseInt(process.versions.node.split('.')[0], 10) >= 12) {
   v8.setFlagsFromString('--no-flush-bytecode'); // Thanks to A-Parser (@a-parser)
-} catch (e) { }
+}
 
 const COMPILED_EXTNAME = '.jsc';
 


### PR DESCRIPTION
Part of #48.

Many apologies, but it seems [my comment](https://github.com/OsamaAbbas/bytenode/issues/48#issuecomment-579681668) was in error. When we try to `setFlagsFromString` and the flag is not recognised, no exception is thrown - so, wrapping the call in a try/catch block, as I suggested, does nothing.

However, what calling `setFlagsFromString` does do is output a message to STDERR. I'm not able to find a way to suppress this in code, but for our purposes it is actually a problem. So, your [original suggestion](https://github.com/OsamaAbbas/bytenode/issues/48#issuecomment-579545999) to use a version test is actually a better solution. This change will prevent `bytenode` from trying to set this flag on Node.js versions below 12.0.0.

I would be happy to use `semver` instead for the version comparison, but I noticed `bytenode` has no production dependencies yet, so I have preserved that.