### PR TITLE
Add the ability to use stdin/stdout with --no-module flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,10 @@ if (args.includes('-v')) {
   args[args.indexOf('-v')] = '--version';
 }
 
+if (args.includes('-n')) {
+  args[args.indexOf('-n')] = '--no-module';
+}
+
 const program = {
   dirname: __dirname,
   filename: __filename,

--- a/cli.js
+++ b/cli.js
@@ -69,7 +69,11 @@ if (program.flags.includes('--compile')) {
     process.stdin.on('end', () => {
 
       try {
-        process.stdout.write(bytenode.compileCode(wrap(script)));
+        if (program.flags.includes('--no-module')) {
+          process.stdout.write(bytenode.compileCode(script));
+        } else {
+          process.stdout.write(bytenode.compileCode(wrap(script)));
+        }
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
I'm writing an `electron-bytenode` module which runs bytenode via a child process (using Electron as Node) and sends data to/from using stdin/stdout. This change allows the `--no-module` option to work through stdio as well.

I've also added an option to use `-n` as shortened form of `--no-module`.