### PR TITLE
ci: update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
     # run pre-flight tests on ubuntu, instead of full OS support matrix, to reduce costs
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
## Problem

CI is currently failing on **every** PR (e.g. #259) at the **Set up job** step, before any test runs:

```
##[error]This request has been automatically failed because it uses a deprecated
version of `actions/cache: v2`. Please update your workflow to use v3/v4 of
actions/cache to avoid interruptions.
```

GitHub has [closed down](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) `actions/cache` v1/v2. The workflow also pins `actions/checkout@v2` and `actions/setup-node@v1`, both of which run on the long-deprecated Node 12/16 action runtimes.

## Change

Bump the pinned actions in `.github/workflows/test.yml` to current majors:

- `actions/checkout@v2` → `v4`
- `actions/setup-node@v1` → `v4`
- `actions/cache@v2` → `v4`

`actions/setup-node@v4` only enables dependency caching when its `cache` input is set, so the existing `actions/cache` step is retained unchanged (the repo has no lockfile, so keying on `package.json` is preserved).

This unblocks CI for `master` and all open/future PRs.

## Notes

- No source or test changes; this is CI-only.
- Follow-up worth considering separately: the Node matrix is `[22.x, 23.x]` and Node 23 is now EOL — bumping to `24.x` would track current releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)