### PR TITLE
ci: test on Node 24.x (bump Electron devDependency to ^41)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [22.x, 23.x]
+        node-version: [22.x, 24.x]
         os: [ubuntu-latest]
 
     # run pre-flight tests on ubuntu, instead of full OS support matrix, to reduce costs

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/bytenode/bytenode#readme",
   "devDependencies": {
-    "electron": "^34.1.1",
+    "electron": "^41.0.0",
     "mocha": "^11.1.0"
   }
 }


### PR DESCRIPTION
## Change

- Test matrix: `23.x` (EOL) → **`24.x`**, alongside `22.x` LTS.
- `electron` devDependency: `^34.1.1` → **`^41.0.0`**.

## Why the Electron bump is required

With the matrix on 24.x, the Electron tests failed with `Electron failed to install correctly`. Root cause (isolated): Electron `<40` unpacks its binary in `install.js` using `extract-zip@2.0.1`, whose extraction relies on `yauzl@2.10.0`'s legacy readable stream piped via `stream.pipeline`. On **Node 24** that `pipeline()` promise **never resolves** (it hangs on the first entry), so the binary is only partially extracted, `path.txt` is never written, and `require('electron')` throws. The binary *download* works fine — only the extraction hangs. This reproduces both locally (Node 24.17) and in CI (Node 24.16), and affects every Electron version that still bundles `extract-zip@2.0.1` (34/37/38).

Electron **40** replaced `extract-zip` with an in-house `@electron-internal/extract-zip` that works on Node 24, so the fix is simply to bump the devDependency.

## Why `^41` and not the latest (42)

Electron 42 ships V8 14.8, whose read-only snapshot checksum mismatch hard-aborts (SIGTRAP) when loading bytecode compiled the current way — the issue addressed by #259. Electron **41** (V8 ≤14.6) installs cleanly on Node 24 **and** runs the existing `compileFile({ electron: true })` tests without needing that fix.

Full suite (15 tests) verified green locally on **Node 24.17 + Electron 41.8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)